### PR TITLE
[add]いいね数を表示する為の処理を追記

### DIFF
--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -30,6 +30,6 @@ class Article extends Model
 
     public function getCountLikesAttribute(): int
     {
-        return $this->likes()->count();
+        return $this->likes->count();
     }
 }

--- a/backend/resources/js/components/ArticleLike.vue
+++ b/backend/resources/js/components/ArticleLike.vue
@@ -8,7 +8,7 @@
       :class="{'red-text':this.isLikedBy}"
       />
     </button>
-    10
+    {{countLikes}}
   </div>
 </template>
 
@@ -19,10 +19,15 @@ export default {
         type: Boolean,
         default: false,
       },
+      initialCountLikes: {
+        type: Number,
+        default: 0,
+      },
     },
     data() {
       return {
         isLikedBy: this.initialIsLikedBy,
+        countLikes: this.initialCountLikes,
       }
     },
   }

--- a/backend/resources/views/articles/post.blade.php
+++ b/backend/resources/views/articles/post.blade.php
@@ -70,7 +70,7 @@
     </div>
     <div class="card-body pt-0 pb-2 pl-3">
         <div class="card-text">
-            <article-like :initial-is-liked-by='@json($article->isLikedBy(Auth::user()))' :initial-count-likes='@json($article->$count_likes)'>
+            <article-like :initial-is-liked-by='@json($article->isLikedBy(Auth::user()))' :initial-count-likes='@json($article->count_likes)'>
             </article-like>
         </div>
     </div>


### PR DESCRIPTION
Article.phpでlikesテーブル内の記事に対するいいね数を算出するメソッドを作成

ArticleLike.vueで親コンポーネントから渡ってくるv-bindディレクティブを使い、
いいね数を表示できるようにpropsプロパティを作成

post.blade.phpでv-bindにいいね数を算出するメソッドの値を代入