### PR TITLE
[add]いいね機能のルーティングとメソッドを追記

### DIFF
--- a/backend/app/Http/Controllers/ArticleController.php
+++ b/backend/app/Http/Controllers/ArticleController.php
@@ -97,4 +97,25 @@ class ArticleController extends Controller
         $article->delete();
         return redirect()->route('articles.index');
     }
+
+    public function like(Request $request, Article $article)
+    {
+        $article->likes()->detach($request->user()->id);
+        $article->likes()->attach($request->user()->id);
+
+        return [
+            'id' => $article->id,
+            'countLikes' => $article->count_likes,
+        ];
+    }
+
+    public function unlike(Request $request, Article $article)
+    {
+        $article->likes()->detach($request->user()->id);
+
+        return [
+            'id' => $article->id,
+            'countLikes' => $article->count_likes,
+        ];
+    }
 }

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -10,11 +10,12 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
-Route::get('/', function () {
-    return view('welcome');
-});
-
 Auth::routes();
 
 Route::resource('/articles', 'ArticleController')->except(['show'])->middleware('auth');
 Route::resource('/articles', 'ArticleController')->only(['show']);
+
+Route::prefix('articles')->name('articles.')->group(function () {
+    Route::put('/{article}/like', 'ArticleController@like')->name('like')->middleware('auth');
+    Route::delete('/{article}/like', 'ArticleController@unlike')->name('unlike')->middleware('auth');
+});


### PR DESCRIPTION
いいねの重複を避ける為にdetachとattachを作成
detachで一度likesテーブルのユーザーと紐付く投稿のいいねを削除
その後attachを使い、likesテーブルでいいねを記録する
returnでattach後のいいね数をクライアントに返す
どの記事へのいいね、あるいはいいね解除が成功したかがわかるよう、
記事モデルのidをレスポンスさせる