### PR TITLE
[add]タグvueコンポーネントでタグのspan対策を追記

### DIFF
--- a/backend/resources/js/components/ArticleTagsInput.vue
+++ b/backend/resources/js/components/ArticleTagsInput.vue
@@ -1,8 +1,14 @@
 <template>
   <div>
+  <input
+      type="hidden"
+      name="tags"
+      :value="tagsJson"
+    >
     <vue-tags-input
       v-model="tag"
       :tags="tags"
+      placeholder="タグを5個まで入力できます"
       :autocomplete-items="filteredItems"
       @tags-changed="newTags => tags = newTags"
     />
@@ -38,6 +44,9 @@ export default {
       return this.autocompleteItems.filter(i => {
         return i.text.toLowerCase().indexOf(this.tag.toLowerCase()) !== -1;
       });
+    },
+    tagsJson() {
+      return JSON.stringify(this.tags)
     },
   },
 };


### PR DESCRIPTION
input=hiddenを使いname=tagsでform送信できるように追記
json形式の文字列で渡すことで、laravel側で連想配列としてタグデータを扱うことができる