### PR TITLE
[add]タグの自動補完機能を追記

### DIFF
--- a/backend/resources/js/components/ArticleTagsInput.vue
+++ b/backend/resources/js/components/ArticleTagsInput.vue
@@ -36,17 +36,6 @@ export default {
     return {
       tag: '',
       tags: this.initialTags,
-      autocompleteItems: [{
-        text: 'Spain',
-      }, {
-        text: 'France',
-      }, {
-        text: 'USA',
-      }, {
-        text: 'Germany',
-      }, {
-        text: 'China',
-      }],
     };
   },
   computed: {

--- a/backend/resources/views/articles/form.blade.php
+++ b/backend/resources/views/articles/form.blade.php
@@ -5,7 +5,7 @@
     <input type="text" name="title" class="form-control" required value="{{ $article->title ?? old('title') }}">
 </div>
 <div class="form-group">
-    <article-tags-input :initial-tags='@json($tagNames ?? [])'>
+    <article-tags-input :initial-tags='@json($tagNames ?? [])' :autocomplete-items='@json($allTagNames ?? [])'>
     </article-tags-input>
 </div>
 <div class="form-group">


### PR DESCRIPTION
form.bladeでv-bindを使いtagテーブルにあるnameカラムを全てvueコンポーネント
に渡す処理を追記
vueコンポーネントで渡ってきた値を使い自動補完の処理を設定