### PR TITLE
[add]ユーザの詳細ページでユーザの投稿一覧を表示させる処理を追記

### DIFF
--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Article;
 use Illuminate\Http\Request;
 use App\Models\User;
 
@@ -10,7 +11,9 @@ class UserController extends Controller
     public function show(string $name)
     {
         $user = User::where('name', $name)->first();
-        return view('users.show', compact('user'));
+
+        $articles = $user->articles->sortByDesc('created_at');
+        return view('users.show', compact('user', 'articles'));
     }
 
     /**

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -6,6 +6,7 @@ use App\Mail\BareMail;
 use App\Notifications\PasswordResetNotification;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -85,5 +86,13 @@ class User extends Authenticatable
     public function getCountFollowingsAttribute(): int
     {
         return $this->followings()->count();
+    }
+
+    /**
+     * 各ユーザーの詳細ページでユーザーの投稿を一覧表示する為のリレーション
+     */
+    public function articles(): HasMany
+    {
+        return $this->hasMany('App\Models\Article');
     }
 }

--- a/backend/resources/views/users/show.blade.php
+++ b/backend/resources/views/users/show.blade.php
@@ -33,5 +33,20 @@
             </div>
         </div>
     </div>
+    <ul class="nav nav-tabs nav-justified mt-3">
+        <li class="nav-item">
+            <a class="nav-link text-muted active" href="{{ route('users.show', ['name' => $user->name]) }}">
+                記事
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link text-muted" href="">
+                いいね
+            </a>
+        </li>
+    </ul>
+    @foreach($articles as $article)
+    @include('articles.post')
+    @endforeach
 </div>
 @endsection


### PR DESCRIPTION
userモデルでarticleモデルと1対多のリレーションを追記
userコントローラーのshowメソッドでユーザが持つarticleモデルのデータを変数に代入
show.blade.phpで詳細を表示するユーザの投稿を一覧で表示できるよう追記