### PR TITLE
[add]いいねした投稿を一覧表示できる処理を追記

### DIFF
--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -13,7 +13,20 @@ class UserController extends Controller
         $user = User::where('name', $name)->first();
 
         $articles = $user->articles->sortByDesc('created_at');
+
         return view('users.show', compact('user', 'articles'));
+    }
+
+    /**
+     * いいねした投稿を一覧表示できるメソッド
+     */
+    public function likes(string $name)
+    {
+        $user = User::where('name', $name)->first();
+
+        $articles = $user->likes->sortByDesc('created_at');
+
+        return view('users.likes', compact('user', 'articles'));
     }
 
     /**

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -95,4 +95,12 @@ class User extends Authenticatable
     {
         return $this->hasMany('App\Models\Article');
     }
+
+    /**
+     * ユーザーがいいねした投稿にアクセスすることを可能にするリレーション
+     */
+    public function likes(): BelongsToMany
+    {
+        return $this->belongsToMany('App\Models\Article', 'likes')->withTimestamps();
+    }
 }

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -10,6 +10,9 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
+
+use App\Http\Controllers\UserController;
+
 Auth::routes();
 
 Route::resource('/articles', 'ArticleController')->except(['show'])->middleware('auth');
@@ -26,6 +29,8 @@ Route::get('/tags/{name}', 'TagController@show')->name('tags.show');
 # ユーザ関連機能
 Route::prefix('users')->name('users.')->group(function () {
     Route::get('/{name}', 'UserController@show')->name('show');
+    // いいねした投稿を一覧で表示
+    Route::get('/{name}/likes', 'UserController@likes')->name('likes');
     Route::middleware('auth')->group(function () {
         Route::put('/{name}/follow', 'UserController@follow')->name('follow');
         Route::delete('/{name}/follow', 'UserController@unfollow')->name('unfollow');


### PR DESCRIPTION
いいねした投稿を一覧表示する為のルーティングを新規作成
Userモデルで中間テーブル(likes)を使い、いいねした投稿を取得するメソッドを追記
UserControllerでbladeに詳細を表示するユーザーモデルと
そのユーザーがいいねした投稿を変数で渡すlikesメソッドを新規作成