### PR TITLE
[add]NEWS API関連機能の追記

### DIFF
--- a/backend/app/Http/Controllers/NewsApiController.php
+++ b/backend/app/Http/Controllers/NewsApiController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\ApiRequest;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7;
+
+class NewsApiController extends Controller
+{
+    public function defaultIndex()
+    {
+        try {
+            $url = config('newsapi.news_api_url') . "top-headlines?country=jp&apiKey=" . config('newsapi.news_api_key');
+            $method = "GET";
+
+            $client = new Client();
+            $response = $client->request($method, $url);
+
+            $results = $response->getBody();
+            $articles = json_decode($results, true);
+
+            $news = [];
+            $count = 20;
+
+            for ($id = 0; $id < $count; $id++) {
+                array_push($news, [
+                    'name' => $articles['articles'][$id]['title'],
+                    'url' => $articles['articles'][$id]['url'],
+                    'thumbnail' => $articles['articles'][$id]['urlToImage'],
+                ]);
+            }
+        } catch (RequestException $e) {
+            echo Psr7\Message::toString($e->getRequest());
+            if ($e->hasResponse()) {
+                echo Psr7\Message::toString($e->getResponse());
+            }
+        }
+        return view('articles.news_index', compact('news'));
+    }
+
+    public function customIndex(ApiRequest $request)
+    {
+        try {
+            if (isset($request)) {
+                $country = $request->country;
+                $category = $request->category;
+                $url = config('newsapi.news_api_url') . "top-headlines?country=" . $country . "&category=" . $category . "&apiKey=" . config('newsapi.news_api_key');
+            }
+
+            $method = "GET";
+
+            $client = new Client();
+            $response = $client->request($method, $url);
+
+            $results = $response->getBody();
+            $articles = json_decode($results, true);
+
+            $news = [];
+            $count = 20;
+
+            for ($id = 0; $id < $count; $id++) {
+                array_push($news, [
+                    'name' => $articles['articles'][$id]['title'],
+                    'url' => $articles['articles'][$id]['url'],
+                    'thumbnail' => $articles['articles'][$id]['urlToImage'],
+                ]);
+            }
+        } catch (RequestException $e) {
+            echo Psr7\Message::toString($e->getRequest());
+            if ($e->hasResponse()) {
+                echo Psr7\Message::toString($e->getResponse());
+            }
+        }
+        return view('articles.news_index', compact('news'));
+    }
+}

--- a/backend/app/Http/Requests/ApiRequest.php
+++ b/backend/app/Http/Requests/ApiRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApiRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'country' => 'required | string',
+            'category' => 'string | nullable'
+        ];
+    }
+    public function attributes()
+    {
+        return [
+            'country' => '国名',
+            'category' => 'カテゴリー',
+        ];
+    }
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -10,6 +10,7 @@
     "require": {
         "php": "^7.2.5|^8.0",
         "fideloper/proxy": "^4.4",
+        "guzzlehttp/guzzle": "^7.3",
         "laravel/framework": "^6.20",
         "laravel/tinker": "^2.5"
     },

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "109e1bbf4ba6fc80a54bf4a39757a565",
+    "content-hash": "54bf3135f409d6eb02ff79db0adadb28",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -383,6 +383,227 @@
                 "trusted proxy"
             ],
             "time": "2020-10-22T13:48:01+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.4",
+                "guzzlehttp/psr7": "^1.7 || ^2.0",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/alexeyshockov",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/gmponos",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-23T11:33:13+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2021-03-07T09:25:29+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "35ea11d335fd638b5882ff1725228b3d35496ab1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/35ea11d335fd638b5882ff1725228b3d35496ab1",
+                "reference": "35ea11d335fd638b5882ff1725228b3d35496ab1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2021-03-21T16:25:00+00:00"
         },
         {
             "name": "laravel/framework",
@@ -1289,6 +1510,105 @@
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.1.3",
             "source": {
@@ -1454,6 +1774,46 @@
                 "shell"
             ],
             "time": "2021-01-18T15:53:43+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "ramsey/uuid",

--- a/backend/config/newsapi.php
+++ b/backend/config/newsapi.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'news_api_url' => env('NEWS_API_URL', null),
+    'news_api_key' => env('NEWS_API_KEY', null),
+];

--- a/backend/resources/views/articles/index.blade.php
+++ b/backend/resources/views/articles/index.blade.php
@@ -5,6 +5,7 @@
 @section('content')
 @include('nav')
 <div class="container">
+    @include('articles.tabs', ['hasNewsApi' => false, 'hasArticles' => true])
     @foreach($articles as $article)
     @include('articles.post')
     @endforeach

--- a/backend/resources/views/articles/news.blade.php
+++ b/backend/resources/views/articles/news.blade.php
@@ -1,0 +1,8 @@
+<div class="card-body pt-0 pb-2">
+    <h3 class="h5 card-title">
+        <a href="{{$data['url']}}">{{$data['name']}}</a>
+    </h3>
+    <div class="card-text">
+        <img src="{{$data['thumbnail']}}">
+    </div>
+</div>

--- a/backend/resources/views/articles/news_index.blade.php
+++ b/backend/resources/views/articles/news_index.blade.php
@@ -1,0 +1,14 @@
+@extends('app')
+
+@section('title', 'ニュース一覧')
+
+@section('content')
+@include('nav')
+<div class="container">
+    @include('articles.tabs', ['hasNewsApi' => true, 'hasArticles' => false])
+    @include('articles.news_tabs')
+    @foreach($news as $data)
+    @include('articles.news')
+    @endforeach
+</div>
+@endsection

--- a/backend/resources/views/articles/news_tabs.blade.php
+++ b/backend/resources/views/articles/news_tabs.blade.php
@@ -1,0 +1,27 @@
+<form method="post" action="{{route('api.custom_index')}}">
+    @csrf
+    <p>
+        <select name="country">
+            <option disabled selected value>未選択</option>
+            <option value="jp" selected>日本</option>
+            <option value="fr">フランス</option>
+            <option value="ca">カナダ</option>
+            <option value="de">ドイツ</option>
+            <option value="gb">イギリス</option>
+            <option value="it">イタリア</option>
+            <option value="us">アメリカ</option>
+            <option value="ru">ロシア</option>
+        </select>
+        <select name="category">
+            <option disabled selected value>未選択</option>
+            <option value="entertainment">entertainment</option>
+            <option value="business">business</option>
+            <option value="general">general</option>
+            <option value="health">health</option>
+            <option value="science">science</option>
+            <option value="sports">sports</option>
+            <option value="technology">technology</option>
+        </select>
+    </p>
+    <p><input type="submit" value="取得する"></p>
+</form>

--- a/backend/resources/views/articles/tabs.blade.php
+++ b/backend/resources/views/articles/tabs.blade.php
@@ -1,0 +1,12 @@
+<ul class="nav nav-tabs nav-justified mt-3">
+    <li class="nav-item">
+        <a class="nav-link text-muted {{ $hasNewsApi ? 'active' : '' }}" href="{{ route('api.default_index') }}">
+            ニュース
+        </a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link text-muted {{ $hasArticles ? 'active' : '' }}" href="{{route('articles.index')}}">
+            投稿
+        </a>
+    </li>
+</ul>

--- a/backend/resources/views/nav.blade.php
+++ b/backend/resources/views/nav.blade.php
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand navbar-dark blue-gradient">
 
-    <a class="navbar-brand" href="/articles"><i class="far fa-sticky-note mr-1"></i>syokumane</a>
+    <a class="navbar-brand" href="{{route('api.default_index')}}"><i class="far fa-sticky-note mr-1"></i>Newsmemo</a>
 
     <ul class="navbar-nav ml-auto">
 

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -40,3 +40,9 @@ Route::prefix('users')->name('users.')->group(function () {
         Route::delete('/{name}/follow', 'UserController@unfollow')->name('unfollow');
     });
 });
+
+# NEWS API関連機能
+Route::prefix('api')->name('api.')->group(function () {
+    Route::get('/default', 'NewsApiController@defaultIndex')->name('default_index');
+    Route::post('/custom', 'NewsApiController@customIndex')->name('custom_index');
+});


### PR DESCRIPTION
NEWS APIを使いデータを取得後、一覧で表示させる機能を追加
ニュースを国別、カテゴリ別で取得できる機能を追加
タブを作成し、ニュース一覧画面と投稿一覧画面を遷移できる機能を追加