### PR TITLE
[add]コロナ関連のニュースタグを追記等

### DIFF
--- a/backend/app/Http/Controllers/CovidNewsController.php
+++ b/backend/app/Http/Controllers/CovidNewsController.php
@@ -3,17 +3,16 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use App\Http\Requests\ApiRequest;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7;
 
-class HeadlineNewsController extends Controller
+class CovidNewsController extends Controller
 {
     public function defaultIndex()
     {
         try {
-            $url = config('newsapi.news_api_url') . "top-headlines?country=jp&pageSize=30&apiKey=" . config('newsapi.news_api_key');
+            $url = config('newsapi.news_api_url') . "everything?q=コロナ&pageSize=40&apiKey=" . config('newsapi.news_api_key');
             $method = "GET";
 
             $client = new Client();
@@ -23,7 +22,7 @@ class HeadlineNewsController extends Controller
             $articles = json_decode($results, true);
 
             $news = [];
-            $count = 30;
+            $count = 40;
 
             for ($id = 0; $id < $count; $id++) {
                 array_push($news, [
@@ -38,16 +37,15 @@ class HeadlineNewsController extends Controller
                 echo Psr7\Message::toString($e->getResponse());
             }
         }
-        return view('articles.news_index', compact('news'));
+        return view('articles.covid_index', compact('news'));
     }
 
-    public function customIndex(ApiRequest $request)
+    public function customIndex(Request $request)
     {
         try {
             if (isset($request)) {
-                $country = $request->country;
-                $category = $request->category;
-                $url = config('newsapi.news_api_url') . "top-headlines?country=" . $country . "&category=" . $category . "&pageSize=30&apiKey=" . config('newsapi.news_api_key');
+                $language = $request->language;
+                $url = config('newsapi.news_api_url') . "everything?q=COVID-19&language=" . $language . "&pageSize=50&apiKey=" . config('newsapi.news_api_key');
             }
 
             $method = "GET";
@@ -59,7 +57,7 @@ class HeadlineNewsController extends Controller
             $articles = json_decode($results, true);
 
             $news = [];
-            $count = 30;
+            $count = 50;
 
             for ($id = 0; $id < $count; $id++) {
                 array_push($news, [
@@ -74,6 +72,6 @@ class HeadlineNewsController extends Controller
                 echo Psr7\Message::toString($e->getResponse());
             }
         }
-        return view('articles.news_index', compact('news'));
+        return view('articles.covid_index', compact('news'));
     }
 }

--- a/backend/resources/views/articles/covid_index.blade.php
+++ b/backend/resources/views/articles/covid_index.blade.php
@@ -1,0 +1,14 @@
+@extends('app')
+
+@section('title', 'COVID-19ニュース一覧')
+
+@section('content')
+@include('nav')
+<div class="container">
+    @include('articles.tabs', ['hasNewsApi' => false, 'hasCovidNews' => true,'hasArticles' => false])
+    @include('articles.covidnews_tabs')
+    @foreach($news as $data)
+    @include('articles.news')
+    @endforeach
+</div>
+@endsection

--- a/backend/resources/views/articles/covidnews_tabs.blade.php
+++ b/backend/resources/views/articles/covidnews_tabs.blade.php
@@ -1,0 +1,17 @@
+<form method="post" action="{{route('api.covid_custom_index')}}">
+    @csrf
+    語圏を選択
+    <select name="language">
+        <option disabled selected value>未選択</option>
+        <option value="jp" selected>日本語</option>
+        <option value="en">英語圏</option>
+        <option value="zh">中国語圏</option>
+        <option value="fr">フランス語圏</option>
+        <option value="pt">ポルトガル語圏</option>
+        <option value="de">ドイツ語圏</option>
+        <option value="es">スペイン語圏</option>
+        <option value="it">イタリア語圏</option>
+        <option value="ru">ロシア語圏</option>
+    </select>
+    <p><input type="submit" value="更新"></p>
+</form>

--- a/backend/resources/views/articles/index.blade.php
+++ b/backend/resources/views/articles/index.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 @include('nav')
 <div class="container">
-    @include('articles.tabs', ['hasNewsApi' => false, 'hasArticles' => true])
+    @include('articles.tabs', ['hasNewsApi' => false, 'hasCovidNews' => false, 'hasArticles' => true])
     @foreach($articles as $article)
     @include('articles.post')
     @endforeach

--- a/backend/resources/views/articles/news_index.blade.php
+++ b/backend/resources/views/articles/news_index.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 @include('nav')
 <div class="container">
-    @include('articles.tabs', ['hasNewsApi' => true, 'hasArticles' => false])
+    @include('articles.tabs', ['hasNewsApi' => true, 'hasCovidNews' => false, 'hasArticles' => false])
     @include('articles.news_tabs')
     @foreach($news as $data)
     @include('articles.news')

--- a/backend/resources/views/articles/news_tabs.blade.php
+++ b/backend/resources/views/articles/news_tabs.blade.php
@@ -1,27 +1,28 @@
 <form method="post" action="{{route('api.custom_index')}}">
     @csrf
-    <p>
-        <select name="country">
-            <option disabled selected value>未選択</option>
-            <option value="jp" selected>日本</option>
-            <option value="fr">フランス</option>
-            <option value="ca">カナダ</option>
-            <option value="de">ドイツ</option>
-            <option value="gb">イギリス</option>
-            <option value="it">イタリア</option>
-            <option value="us">アメリカ</option>
-            <option value="ru">ロシア</option>
-        </select>
-        <select name="category">
-            <option disabled selected value>未選択</option>
-            <option value="entertainment">entertainment</option>
-            <option value="business">business</option>
-            <option value="general">general</option>
-            <option value="health">health</option>
-            <option value="science">science</option>
-            <option value="sports">sports</option>
-            <option value="technology">technology</option>
-        </select>
-    </p>
-    <p><input type="submit" value="取得する"></p>
+    国名:
+    <select name="country">
+        <option disabled selected value>未選択</option>
+        <option value="jp" selected>日本</option>
+        <option value="fr">フランス</option>
+        <option value="ca">カナダ</option>
+        <option value="de">ドイツ</option>
+        <option value="gb">イギリス</option>
+        <option value="it">イタリア</option>
+        <option value="us">アメリカ</option>
+        <option value="ru">ロシア</option>
+    </select>
+    カテゴリー:
+    <select name="category">
+        <option disabled selected value>未選択</option>
+        <option value="entertainment">entertainment</option>
+        <option value="business">business</option>
+        <option value="general">general</option>
+        <option value="health">health</option>
+        <option value="science">science</option>
+        <option value="sports">sports</option>
+        <option value="technology">technology</option>
+    </select>
+
+    <p><input type="submit" value="更新"></p>
 </form>

--- a/backend/resources/views/articles/tabs.blade.php
+++ b/backend/resources/views/articles/tabs.blade.php
@@ -5,6 +5,11 @@
         </a>
     </li>
     <li class="nav-item">
+        <a class="nav-link text-muted {{ $hasCovidNews ? 'active' : '' }}" href="{{ route('api.covid_default_index') }}">
+            COVID-19
+        </a>
+    </li>
+    <li class="nav-item">
         <a class="nav-link text-muted {{ $hasArticles ? 'active' : '' }}" href="{{route('articles.index')}}">
             メモリスト
         </a>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -45,4 +45,6 @@ Route::prefix('users')->name('users.')->group(function () {
 Route::prefix('api')->name('api.')->group(function () {
     Route::get('/default', 'HeadlineNewsController@defaultIndex')->name('default_index');
     Route::post('/custom', 'HeadlineNewsController@customIndex')->name('custom_index');
+    Route::get('/covid/default', 'CovidNewsController@defaultIndex')->name('covid_default_index');
+    Route::post('/covid/custom', 'CovidNewsController@customIndex')->name('covid_custom_index');
 });


### PR DESCRIPTION
コロナ関連の記事を表示するコントローラーやメソッド、bladeを追記
トップスのセレクトボックスを修正
トップスの表示件数の修正
トップページのタグを修正