### PR TITLE
[update]マイページの表示方法を修正

### DIFF
--- a/backend/resources/views/articles/covid_index.blade.php
+++ b/backend/resources/views/articles/covid_index.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 @include('nav')
 <div class="container">
-    @include('articles.tabs', ['hasNewsApi' => false, 'hasCovidNews' => true,'hasArticles' => false])
+    @include('articles.tabs', ['hasNewsApi' => false, 'hasCovidNews' => true,'hasArticles' => false,'hasMypage' => false])
     @include('articles.covidnews_tabs')
     @foreach($news as $data)
     @include('articles.news')

--- a/backend/resources/views/articles/index.blade.php
+++ b/backend/resources/views/articles/index.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 @include('nav')
 <div class="container">
-    @include('articles.tabs', ['hasNewsApi' => false, 'hasCovidNews' => false, 'hasArticles' => true])
+    @include('articles.tabs', ['hasNewsApi' => false, 'hasCovidNews' => false, 'hasArticles' => true,'hasMypage' => false])
     @foreach($articles as $article)
     @include('articles.post')
     @endforeach

--- a/backend/resources/views/articles/news_index.blade.php
+++ b/backend/resources/views/articles/news_index.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 @include('nav')
 <div class="container">
-    @include('articles.tabs', ['hasNewsApi' => true, 'hasCovidNews' => false, 'hasArticles' => false])
+    @include('articles.tabs', ['hasNewsApi' => true, 'hasCovidNews' => false, 'hasArticles' => false,'hasMypage' => false])
     @include('articles.news_tabs')
     @foreach($news as $data)
     @include('articles.news')

--- a/backend/resources/views/articles/tabs.blade.php
+++ b/backend/resources/views/articles/tabs.blade.php
@@ -14,4 +14,9 @@
             メモリスト
         </a>
     </li>
+    <li class="nav-item">
+        <a class="nav-link text-muted {{ $hasMypage ? 'active' : '' }}" href="{{route('users.show', ["name" => Auth::user()->name])}}">
+            マイページ
+        </a>
+    </li>
 </ul>

--- a/backend/resources/views/users/show.blade.php
+++ b/backend/resources/views/users/show.blade.php
@@ -5,6 +5,7 @@
 @section('content')
 @include('nav')
 <div class="container">
+    @include('articles.tabs', ['hasNewsApi' => false, 'hasCovidNews' => false,'hasArticles' => false,'hasMypage' => true])
     @include('users.profile')
     @include('users.tabs', ['hasArticles' => true, 'hasLikes' => false])
     @foreach($articles as $article)


### PR DESCRIPTION
マイページをニュースやメモ一覧と同じタグ欄から遷移できるように修正
利用者の選択肢を減らし直感的に分かりやすくすることが目的
(修正するブランチ間違え->今後、機能の修正はfeature/updateで行う)