### PR TITLE
[update]タグ別でメモを一覧表示する際の修正

### DIFF
--- a/backend/resources/views/tags/show.blade.php
+++ b/backend/resources/views/tags/show.blade.php
@@ -5,14 +5,8 @@
 @section('content')
 @include('nav')
 <div class="container">
-    <div class="card mt-3">
-        <div class="card-body">
-            <h2 class="h4 card-title m-0">{{ $tag->hashtag }}</h2>
-            <div class="card-text text-right">
-                {{ $tag->articles->count() }}件
-            </div>
-        </div>
-    </div>
+    @include('articles.tabs', ['hasNewsApi' => false, 'hasCovidNews' => false, 'hasArticles' => true,'hasMypage' => false])
+    @include('tags.tags')
     @foreach($tag->articles as $article)
     @include('articles.post')
     @endforeach

--- a/backend/resources/views/tags/tags.blade.php
+++ b/backend/resources/views/tags/tags.blade.php
@@ -1,0 +1,8 @@
+<div class="card mt-3">
+    <div class="card-body d-flex flex-row">
+        <h2 class="h4 card-title m-0">{{ $tag->hashtag }}</h2>
+        <div class="card-text text-right">
+            {{ $tag->articles->count() }}件
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
トップページと同様にタグを一覧で表示させておくよう追記
タグ別に表示するbladeを切り離して変更しやすいように修正