### PR TITLE
[update]投稿機能においてニュースのデータを紐付けて投稿できるように修正

### DIFF
--- a/backend/app/Http/Controllers/ArticleController.php
+++ b/backend/app/Http/Controllers/ArticleController.php
@@ -6,6 +6,7 @@ use App\Models\Article;
 use App\Models\Tag;
 use Illuminate\Http\Request;
 use App\Http\Requests\ArticleRequest;
+use Illuminate\Foundation\Console\Presets\React;
 use Illuminate\Support\Facades\Auth;
 
 class ArticleController extends Controller
@@ -32,14 +33,17 @@ class ArticleController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function create()
+    public function create(Request $request)
     {
 
         $allTagNames = Tag::all()->map(function ($tag) {
             return ['text' => $tag->name];
         });
 
-        return view('articles.create', compact('allTagNames'));
+        $news = $request->news;
+        $url = $request->url;
+
+        return view('articles.create', compact('allTagNames', 'news', 'url'));
     }
 
     /**

--- a/backend/resources/views/articles/create.blade.php
+++ b/backend/resources/views/articles/create.blade.php
@@ -12,8 +12,8 @@
                     @include('error_list')
                     <div class="card-text">
                         <form method="POST" action="{{ route('articles.store') }}">
+                            @csrf
                             @include('articles.form')
-                            <button type="submit" class="btn blue-gradient btn-block">投稿する</button>
                         </form>
                     </div>
                 </div>

--- a/backend/resources/views/articles/form.blade.php
+++ b/backend/resources/views/articles/form.blade.php
@@ -12,3 +12,6 @@
     <label></label>
     <textarea name="body" required class="form-control" rows="16" placeholder="本文">{{ $article->body ?? old('body') }}</textarea>
 </div>
+<div class="card-footer text-muted mb-3">関連記事:&nbsp;<a href="{{$url}}" target=”_blank” rel="noopener noreferrer">{{$news}}</a>
+</div>
+<button type="submit" class="btn blue-gradient btn-block">投稿する</button>

--- a/backend/resources/views/articles/news.blade.php
+++ b/backend/resources/views/articles/news.blade.php
@@ -5,7 +5,13 @@
     <img src="{{asset('/assets/images/noimage.png')}}" class="card-img-top img-fluid img-thumbnail" alt="Noimage" />
     @endif
     <div class="card-body">
-        <h5 class="card-title"><a href="{{$data['url']}}" target=”_blank” rel="noopener noreferrer">{{$data['name']}}</a></h5>
-        <a href="{{route('articles.create')}}" class="btn btn-primary">メモする</a>
+        <h5 class="card-title"><a href="{{$data['url']}}" target=”_blank” rel="noopener noreferrer">{{$data['name']}}
+            </a></h5>
+        <form action="{{route('articles.create')}}" method="POST">
+            @csrf
+            <input type="hidden" name="news" value="{{$data['name']}}">
+            <input type="hidden" name="url" value="{{$data['url']}}">
+            <input type="submit" value="メモする">
+        </form>
     </div>
 </div>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -15,8 +15,9 @@ use App\Http\Controllers\UserController;
 
 Auth::routes();
 
-Route::resource('/articles', 'ArticleController')->except(['show'])->middleware('auth');
+Route::resource('/articles', 'ArticleController')->except(['show', 'create'])->middleware('auth');
 Route::resource('/articles', 'ArticleController')->only(['show']);
+Route::post('/articles/create', 'ArticleController@create')->name('articles.create')->middleware('auth');
 
 Route::prefix('articles')->name('articles.')->group(function () {
     Route::put('/{article}/like', 'ArticleController@like')->name('like')->middleware('auth');


### PR DESCRIPTION
news.bladeでnewsapiから取得したデータを投稿機能で使えるようにformを作成後、
hiddenでタイトルとurlの値をcreateのルーティングに渡せるよう追記
createのルーティングのメソッドをgetからpostに変更する為に、createだけ新規作成
ArticleControllerのcreateメソッドでnews.bladeのformから値を受け取り
create.bladeに渡せるように修正
create.bladeで、渡ってきた値(ニュースのタイトルとリンク先)を表示するよう修正
formで@csrfが抜けている箇所が見つかったので修正