### PR TITLE
[add]NEWSAPIから取得したデータを投稿と紐付けて保存できるよう追記

### DIFF
--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -10,7 +10,7 @@ class Article extends Model
 {
 
     protected $fillable = [
-        'title', 'body',
+        'title', 'body', 'news', 'url',
     ];
 
     public function user(): BelongsTo

--- a/backend/database/migrations/2021_04_14_161439_add_news_url_to_articles_table.php
+++ b/backend/database/migrations/2021_04_14_161439_add_news_url_to_articles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNewsUrlToArticlesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->string('news')->after('body');
+            $table->string('url')->after('news');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/backend/resources/views/articles/form.blade.php
+++ b/backend/resources/views/articles/form.blade.php
@@ -12,6 +12,9 @@
     <label></label>
     <textarea name="body" required class="form-control" rows="16" placeholder="本文">{{ $article->body ?? old('body') }}</textarea>
 </div>
-<div class="card-footer text-muted mb-3">関連記事:&nbsp;<a href="{{$url}}" target=”_blank” rel="noopener noreferrer">{{$news}}</a>
+<div class="form-group card-footer text-muted mb-3">
+    <input type="hidden" name="news" value="{{$news}}">
+    <input type="hidden" name="url" value="{{$url}}">
+    関連記事:&nbsp;<a href="{{$url}}" target=”_blank” rel="noopener noreferrer">{{$news}}</a>
 </div>
 <button type="submit" class="btn blue-gradient btn-block">投稿する</button>

--- a/backend/resources/views/articles/post.blade.php
+++ b/backend/resources/views/articles/post.blade.php
@@ -85,6 +85,9 @@
     </div>
     @endif
     @endforeach
+    <div class="card-text pt-0 pb-2 pl-3">
+        関連記事:<a href="{{$article->url}}" target=”_blank” rel="noopener noreferrer">{{$article->news}}</a>
+    </div>
     <div class="card-body pt-0 pb-2 pl-3">
         <div class="card-text">
             <article-like :initial-is-liked-by='@json($article->isLikedBy(Auth::user()))' :initial-count-likes='@json($article->count_likes)' :authorized='@json(Auth::check())' endpoint="{{ route('articles.like', ['article' => $article]) }}">


### PR DESCRIPTION
articlesテーブルにnewsとurlのカラムを追加
その他、新規カラム作成に伴いArticleモデルやform、post.bladeに追記