### PR TITLE
[update]プロフィールアイコンの編集機能を修正

### DIFF
--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -35,7 +35,35 @@ class UserController extends Controller
     {
         $user = User::where('name', $name)->first();
 
-        $user->fill($request->all())->save();
+        $user->fill(['name' => $request->name, 'email' => $request->email, 'introduction' => $request->introduction])->save();
+
+        return redirect()->route('users.show', ['name' => $user->name]);
+    }
+
+    /**
+     * プロフィールアイコンの編集画面を表示
+     */
+    public function imageEdit(string $name)
+    {
+        $user = User::where('name', $name)->first();
+
+        return view('users.image_edit', compact('user'));
+    }
+
+    /**
+     * プロフィールアイコンの更新
+     */
+    public function imageUpdate(UserRequest $request, string $name)
+    {
+        $user = User::where('name', $name)->first();
+
+        $image = $request->image;
+
+        if ($image->isValid()) {
+            $filePath = $image->store('public');
+            $user->image = str_replace('public/', '', $filePath);
+            $user->save();
+        }
 
         return redirect()->route('users.show', ['name' => $user->name]);
     }

--- a/backend/app/Http/Requests/UserRequest.php
+++ b/backend/app/Http/Requests/UserRequest.php
@@ -29,6 +29,7 @@ class UserRequest extends FormRequest
             'name' => 'required | string | min:1 | max:25',
             'email' => 'required | string | email | max:255 |' . Rule::unique('users')->ignore(Auth::id()),
             'introduction' => 'string | max:200 | nullable',
+            'image' => 'file | mimes:jpeg,png,jpg,bmb | max:2048 | nullable',
         ];
     }
 }

--- a/backend/database/migrations/2021_04_15_162505_add_image_to_users_table.php
+++ b/backend/database/migrations/2021_04_15_162505_add_image_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddImageToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('image')->after('introduction')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/backend/resources/views/articles/post.blade.php
+++ b/backend/resources/views/articles/post.blade.php
@@ -1,7 +1,11 @@
 <div class="card mt-3">
     <div class="card-body d-flex flex-row">
         <a href="{{route('users.show',['name'=>$article->user->name])}}" class="text-dark">
+            @if(empty($article->user->image))
             <i class="fas fa-user-circle fa-3x mr-1"></i>
+            @else
+            <img class="profile-icon image-upload rounded-circle img-responsive mr-1" src="/storage/{{$article->user->image}}" width="55" height="55" alt="ユーザーアイコン">
+            @endif
         </a>
         <div>
             <div class="font-weight-bold">

--- a/backend/resources/views/users/edit.blade.php
+++ b/backend/resources/views/users/edit.blade.php
@@ -32,14 +32,11 @@
                                 </label>
                                 <textarea name="introduction" class="form-control" id="introduction" cols="3" rows="3">{{$user->introduction ?? old('introduction')}}</textarea>
                             </div>
-                            <div class='btn-toolbar' role="toolbar">
-                                <div>
-                                    <a href="{{route('users.show',['name' => $user->name])}}"><button class="btn blue-gradient mt-2 mb-2" type="submit">キャンセル</button></a>
-                                    <button class="btn blue-gradient mt-2 mb-2" type="submit">更新</button>
-                                </div>
+                            <div class='btn-toolbar float-right' role="toolbar">
+                                <button class="btn blue-gradient mt-2 mb-2" type="submit">更新</button>
                             </div>
-
                         </form>
+                        <a href="{{route('users.show',['name' => $user->name])}}"><button class="btn blue-gradient mt-2 mb-2 float-left" type="submit">キャンセル</button></a>
                     </div>
                 </div>
             </div>

--- a/backend/resources/views/users/image_edit.blade.php
+++ b/backend/resources/views/users/image_edit.blade.php
@@ -1,0 +1,37 @@
+@extends('app')
+
+@section('title','ユーザー登録')
+
+@section('content')
+@include('nav')
+<div class="container">
+    <div class="row">
+        <div class="mx-auto col col-12 col-sm-11 col-md-9 col-lg-7 col-xl-6">
+            <div class="card mt-3">
+                <div class="card-body text-center">
+                    <h2 class="h3 card-title text-center mt-2">ユーザーアイコンの編集</h2>
+
+                    @include('error_list')
+
+                    <div class="card-text">
+                        <form action="{{route('users.imageUpdate',['name' => $user->name])}}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            @method('PATCH')
+                            <div class="form-group">
+                                <label for="image">プロフィール画像</label>
+                                <input type="file" class="form-control" id="image" name="image" value="{{$user->image}}">
+                            </div>
+                            <input type="hidden" class="form-control" id="email" name="email" value="{{$user->email}}">
+                            <input type="hidden" class="form-control" id="name" name="name" value="{{$user->name}}">
+                            <div class='btn-toolbar float-right' role="toolbar">
+                                <button class="btn blue-gradient mt-2 mb-2" type="submit">更新</button>
+                            </div>
+                        </form>
+                        <a href="{{route('users.show',['name' => $user->name])}}"><button class="btn blue-gradient mt-2 mb-2 float-left" type="submit">キャンセル</button></a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/backend/resources/views/users/profile.blade.php
+++ b/backend/resources/views/users/profile.blade.php
@@ -1,9 +1,24 @@
     <div class="card mt-3">
         <div class="card-body">
             <div class="d-flex flex-row">
-                <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
-                    <i class="fas fa-user-circle fa-3x"></i>
+                @if(Auth::id() == $user->id)
+                <a href="{{ route('users.imageEdit', ['name' => $user->name]) }}" class="text-dark">
+                    @if(empty($user->image))
+                    <i class="fas fa-user-circle fa-3x mr-1"></i>
+                    @else
+                    <img class="profile-icon image-upload rounded-circle img-responsive" src="/storage/{{$user->image}}" width="60" height="60" alt="ユーザーアイコン">
+                    @endif
                 </a>
+                @endif
+                @if(Auth::id() !== $user->id)
+                <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
+                    @if(empty($user->image))
+                    <i class="fas fa-user-circle fa-3x mr-1"></i>
+                    @else
+                    <img class="profile-icon image-upload rounded-circle img-responsive" src="/storage/{{$user->image}}" width="60" height="60" alt="ユーザーアイコン">
+                    @endif
+                </a>
+                @endif
                 @if(Auth::id() !== $user->id)
                 <follow-button :initial-is-followed-by='@json($user->isFollowedBy(Auth::user()))' :authorized='@json(Auth::check())' endpoint="{{ route('users.follow', ['name' => $user->name]) }}">
                 </follow-button>
@@ -17,9 +32,11 @@
             <div class="card-text">
                 {{$user->introduction}}
             </div>
+            @if(Auth::id() == $user->id)
             <div class="card-text mt-2">
                 <a href="{{route('users.edit',['name' => $user->name])}}"><input type="button" class="btn btn-info" value="編集"></a>
             </div>
+            @endif
         </div>
 
         <div class="card-body">

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -39,6 +39,10 @@ Route::prefix('users')->name('users.')->group(function () {
     Route::get('/{name}/edit', 'UserController@edit')->name('edit');
     // プロフィールの更新
     Route::patch('/{name}/update', 'UserController@update')->name('update');
+    // プロフィールアイコンの編集画面を表示
+    Route::get('/{name}/image/edit', 'UserController@imageEdit')->name('imageEdit');
+    // プロフィールアイコンの更新
+    Route::patch('/{name}/image/update', 'UserController@imageUpdate')->name('imageUpdate');
     // フォロー、フォロー解除
     Route::middleware('auth')->group(function () {
         Route::put('/{name}/follow', 'UserController@follow')->name('follow');


### PR DESCRIPTION
[error]Call to a member function load() on nullを避ける為に
プロフィール編集とは別でアイコン編集用のルーティンング、メソッド、bladeを作成
ユーザーがアイコン未設定時にbootstrapのiconsを表示するよう修正
ログインしているユーザーのidとプロフィール欄で表示する内容のユーザーid
が一致している場合のみ編集機能を使用可能に修正